### PR TITLE
fixed import issue in Recursion/Unwinding folder

### DIFF
--- a/04-recursion/02-unwinding/sum-up-to-test.js
+++ b/04-recursion/02-unwinding/sum-up-to-test.js
@@ -1,3 +1,5 @@
+const sumUpTo = require('./sum-up-to')
+
 test('Summing up positive integers', () => {
   expect(sumUpTo(5)).toBe(15);
   expect(sumUpTo(10)).toBe(55);


### PR DESCRIPTION
## What does this PR do?    
There was no import statement for sumUpTo() in the jest test file leading to failing in the test cases   
bug-fix/#17    

## Before   
<img width="416" alt="Screenshot 2023-11-06 111640" src="https://github.com/bradtraversy/traversy-js-challenges/assets/107710864/d598a048-8be5-4c59-8e21-35f482e35383">
   
## After    
<img width="416" alt="Screenshot 2023-11-06 111701" src="https://github.com/bradtraversy/traversy-js-challenges/assets/107710864/2c6739ce-54f3-4d82-adda-5fe93a264593">

## Fixes   
Added import statement in line 1