### PR TITLE
fixing expected result for testcase from -9 to -11 to match sliding w…

### DIFF
--- a/05-complexity/10-max-subarray-linear/max-subarray-linear-test.js
+++ b/05-complexity/10-max-subarray-linear/max-subarray-linear-test.js
@@ -7,5 +7,5 @@ test('Finding maximum subarray sum using O(n^2) solution', () => {
 
   const arr2 = [-2, -5, -3, -1, -11, -7, -6, -4];
   const k2 = 4;
-  expect(maxSubarraySum(arr2, k2)).toBe(-9);
+  expect(maxSubarraySum(arr2, k2)).toBe(-11);
 });

--- a/05-complexity/10-max-subarray-linear/readme.md
+++ b/05-complexity/10-max-subarray-linear/readme.md
@@ -25,7 +25,7 @@ console.log(maxSubarraySum(arr1, k1)); // Output: 24
 
 const arr2 = [-2, -5, -3, -1, -11, -7, -6, -4];
 const k2 = 4;
-console.log(maxSubarraySum(arr2, k2)); // Output: -9
+console.log(maxSubarraySum(arr2, k2)); // Output: -11
 ```
 
 ### Constraints


### PR DESCRIPTION
This test has the same inputs as in  08-max-subarray-quadratic-test.js
There the expected output is -11
  const arr2 = [-2, -5, -3, -1, -11, -7, -6, -4];
  const k2 = 4;
  expect(maxSubarraySum(arr2, k2)).toBe(-11);

Where as in 
10-max-subarray-linear-test.js
  const arr2 = [-2, -5, -3, -1, -11, -7, -6, -4];
  const k2 = 4;
  expect(maxSubarraySum(arr2, k2)).toBe(-9);
the expected output was -9.

-9 would be correct for window size of 3.
For a sliding window of 4 as in the test... -11 should be the expected result.