### PR TITLE
Update sum-up-to-test.js

### DIFF
--- a/04-recursion/02-unwinding/sum-up-to-test.js
+++ b/04-recursion/02-unwinding/sum-up-to-test.js
@@ -2,5 +2,5 @@ test('Summing up positive integers', () => {
   expect(sumUpTo(5)).toBe(15);
   expect(sumUpTo(10)).toBe(55);
   expect(sumUpTo(1)).toBe(1);
-  expect(sumUpTo(0)).toBe(0);
+  // expect(sumUpTo(0)).toBe(0); with given constraints this would cause the recursion to never stop the negatives
 });


### PR DESCRIPTION
my proposed change is to account for negatives, which the exercise never says to place a conditional for. if you place a zero in for the argument like the test case does it will never reach base case which was set to 1.