### PR TITLE
Update max-subarray-linear-test.js

### DIFF
--- a/05-complexity/10-max-subarray-linear/max-subarray-linear-test.js
+++ b/05-complexity/10-max-subarray-linear/max-subarray-linear-test.js
@@ -1,6 +1,6 @@
 const maxSubarraySum = require('./max-subarray-linear');
 
-test('Finding maximum subarray sum using O(n^2) solution', () => {
+test('Finding maximum subarray sum using O(n) solution', () => {
   const arr1 = [2, 5, 3, 1, 11, 7, 6, 4];
   const k1 = 3;
   expect(maxSubarraySum(arr1, k1)).toBe(24);


### PR DESCRIPTION
Fix time complexity typo from `O(n^2)` to `O(n)`.